### PR TITLE
Fix/resizabletextfocus

### DIFF
--- a/Components/ResizableText/ResizableField/ControlManifest.Input.xml
+++ b/Components/ResizableText/ResizableField/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest>
-  <control namespace="PCF" constructor="ResizableField" version="1.0.0"
+  <control namespace="PCF" constructor="ResizableField" version="1.0.1"
     display-name-key="Resizable Textarea"
     description-key="Resizable Multiline Text, with multilingual Placeholder text."
     control-type="virtual" preview-image="img/preview.png">

--- a/Components/ResizableText/ResizableField/ResizableText.tsx
+++ b/Components/ResizableText/ResizableField/ResizableText.tsx
@@ -1,5 +1,6 @@
 ﻿import { FluentProvider, IdPrefixProvider, makeStyles, Textarea, webLightTheme } from '@fluentui/react-components';
 import * as React from "react";
+import { useRef } from 'react';
 import { Utils } from "../../_Utils";
 
 export type ResizableTextProps = {
@@ -24,6 +25,7 @@ const useStyles = makeStyles({
 
 const ResizableText = (props: ResizableTextProps): JSX.Element => {
     const styles = useStyles();
+    const inputReference = useRef<HTMLTextAreaElement | null>(null);
     const { textValue, placeHolderText, disabled, masked, lcid, height, maxHeight, resizeChoice, onChange } = props;
 
     const textAreaHeightStyle = React.useMemo(() => ({
@@ -42,16 +44,22 @@ const ResizableText = (props: ResizableTextProps): JSX.Element => {
         }
     }
 
+    // inform PCF component about value change AFTER the focus out
+    // this ensures the control doesn't lose focus "randomly" and is aligned with how the out-of-the-box control works
+    const onFocusOut = (_: React.ChangeEvent<HTMLTextAreaElement>) => {
+        onChange(inputReference?.current?.value ?? "");
+    }
+
     return (<IdPrefixProvider value="PCF-ResizableTextArea" >
         <FluentProvider theme={webLightTheme} className={styles.container} >
                 <Textarea
                 resize={getResizeChoice(resizeChoice)}
                 placeholder={Utils.GetValueLocalized(placeHolderText, lcid)}
-                    defaultValue={masked? "***":textValue}
-                    onChange={(_, data) => onChange(data?.value ?? "")}
-                    className={styles.container}
-                    textarea={{ style: textAreaHeightStyle }}
-                    disabled={disabled}
+                defaultValue={masked? "***":textValue}
+                onBlur={onFocusOut}
+                className={styles.container}
+                textarea={{ style: textAreaHeightStyle }}
+                disabled={disabled}
                 />
         </FluentProvider>
     </IdPrefixProvider >

--- a/Components/ResizableText/ResizableField/index.ts
+++ b/Components/ResizableText/ResizableField/index.ts
@@ -46,11 +46,13 @@ export class ResizableField implements ComponentFramework.ReactControl<IInputs, 
     public updateView(context: ComponentFramework.Context<IInputs>): React.ReactElement {
         const { sourceControl, placeholderHint, resizeChoice, height, maxHeight } = context.parameters;
 
-        if(this.triggerRerender===false){
-            this.triggerRerender=true;  //reset the flag to ensure that the control re-renders when the text is updated by the model-driven app
-        }
-        else{
-            this.key = Date.now().toString(); //update the key value to force the control to re-render
+        if (context.updatedProperties.indexOf("sourceControl") > -1) {
+            if (this.triggerRerender === false) {
+                this.triggerRerender = true;  //reset the flag to ensure that the control re-renders when the text is updated by the model-driven app
+            }
+            else {
+                this.key = Date.now().toString(); //update the key value to force the control to re-render
+            }
         }
 
         let disabled = context.mode.isControlDisabled;

--- a/Components/ResizableText/package.json
+++ b/Components/ResizableText/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcf-project",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Project containing your PowerApps Component Framework (PCF) control.",
   "scripts": {
     "build": "pcf-scripts build",

--- a/MultilingualComponents/src/Other/Solution.xml
+++ b/MultilingualComponents/src/Other/Solution.xml
@@ -8,7 +8,7 @@
       <LocalizedName description="MultilingualComponents" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.1</Version>
+    <Version>1.1.1.0</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ See more: [Risk Calculations](./Components/RiskCalculations/README.md)
 
 To rebuild the solution after you customized the components, run:
 
+from ./Components/_Utils folder:
+```bash
+npm i
+npm run build
+```
+
+from ./MultilingualComponents folder:
 ```bash
 msbuild /t:build /restore
 ```


### PR DESCRIPTION
Fix: The "Resizable Textarea" was sometimes losing focus, when a user was typing. To address it, and to follow  [Best practices for code components ](https://learn.microsoft.com/en-us/power-apps/developer/component-framework/code-components-best-practices), the `OnChange` is only called when the text area loses focus. 
This behavior is aligned with the out-of-the-box text area control